### PR TITLE
Fix error detection for tests in CI

### DIFF
--- a/.github/workflows/ci_for_stack_poetry_pre-commit_pytest.yaml
+++ b/.github/workflows/ci_for_stack_poetry_pre-commit_pytest.yaml
@@ -109,7 +109,10 @@ jobs:
         uses: mxschmitt/action-tmate@v3
 
       - name: Test with pytest
-        run: poetry run pytest --cov=${{ inputs.package-name }} --cov-report=term-missing:skip-covered --junitxml=pytest.xml ${{ inputs.tests-dir }} | tee pytest-coverage.txt
+        run: |
+          set -o pipefail  # To avoid the tee to rewrite the pytest exit code
+          poetry run pytest --cov=${{ inputs.package-name }} --cov-report=term-missing:skip-covered --junitxml=pytest.xml ${{ inputs.tests-dir }} | tee pytest-coverage.txt
+
 
       - name: Pytest coverage comment
         id: coverage_comment

--- a/.github/workflows/ci_for_stack_poetry_pre-commit_pytest.yaml
+++ b/.github/workflows/ci_for_stack_poetry_pre-commit_pytest.yaml
@@ -105,8 +105,8 @@ jobs:
         run: poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Test with pytest
         run: poetry run pytest --cov=${{ inputs.package-name }} --cov-report=term-missing:skip-covered --junitxml=pytest.xml ${{ inputs.tests-dir }} | tee pytest-coverage.txt

--- a/.github/workflows/ci_for_stack_poetry_pre-commit_pytest.yaml
+++ b/.github/workflows/ci_for_stack_poetry_pre-commit_pytest.yaml
@@ -105,8 +105,8 @@ jobs:
         run: poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
`tee pytest-coverage.txt` was rewriting the `pytest` return code so the failed tests were not visible to the workflow